### PR TITLE
Add risk to stand down reflections and remove abandoned ways

### DIFF
--- a/source/documentation/team-information/team-practises/ways-of-working.html.md.erb
+++ b/source/documentation/team-information/team-practises/ways-of-working.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Ways of Working
-last_reviewed_on: 2025-06-25
+last_reviewed_on: 2025-07-25
 review_in: 3 months
 ---
 
@@ -182,29 +182,6 @@ Sprint planning will now be conducted in three stages to prepare our tickets for
 
 By breaking the sprint planning into these three distinct parts, we aim to improve preparation, reduce uncertainty, and optimise the time spent in planning. This approach also ensures that the team is well-prepared to tackle the sprint's tasks with clear expectations and a shared understanding.
 
-### **✅ Emergency Sprint Planning**
-
-In the event that we complete our sprint goal, and we have insufficient stories in the sprint backlog during a sprint we can call and emergency sprint planning session.
-
-If an emergency planning session is called we should agree as a team whether to hold the session. We may want to consider risk or other stories from the backlog in the first instance.
-
-The emergency planning will be a scalled down version of sprint planning, but follow the same format.
-
-### **✅ Firebreak Sprint Planning**
-
-When running a sprint planning session during a Firebreak, we aim to structure is as follows:
-
-1. **Initial Sprint Planning Session (~10 minutes):**
-   Much the same as regular planning, the first part of the meeting is a brief session led by the Project Manager. The goal is to provide an overview of the upcoming items in the Firebreak sprint and a rough sorting of the relevant tickets. We should also take some time here to briefly review the current Firebreak milestones to make sure the team is happy with their purpose and currently assigned tickets.
-
-2. **Individual User Presentations (~30 minutes):**
-   This section of the meeting gives each team member an opportunity to present their idea for a Firebreak story to the rest of the team. This will help ensure everyone understands what work is required to complete the story, and gives the team a changes to ask questions and challenge or suggest alternatives for the proposed approach.
-
-   It's important here for the team to agree that the proposed Firebreak story is appropriately sized for the sprint.
-
-3. **Firebreak Epics and Sub Issues (~20 minutes):**
-   This portion of the meeting gives us some time to associate any new Firebreak stories with the appropriate Firebreak milestones. If a ticket is not relevant to a milestone, it can be brought in as a standalone story.
-
 ### **✅ Daily Stand-Up Meetings**
 
 Our team holds daily stand-up meetings* in the morning to improve communication and collaboration. This consistent timing
@@ -229,7 +206,7 @@ Post a brief update in the designated Slack channel if you cannot attend stand-u
 and any help you need keeps the team informed and ensures we can support each other effectively, even when we're not
 physically present.
 
-### **✅ Stand-Down Reflections for Continuous Growth**
+### **💡 Stand-Down Reflections for Continuous Growth**
 
 As we wrap up the day, let's reflect and share a moment in our Stand-Down thread. Post updates to celebrate
 progress, voice frustrations to seek support, and highlight wins to spread joy. This transparency fosters teamwork and
@@ -237,6 +214,7 @@ growth.
 
 - **Updates**: Please make sure to note what you've accomplished.
 - **Frustrations**: Share any obstacles - remember, it's us against the problem.
+- **Risks**: Thinking about your obstacles - do we need to escalate these on the risk register
 - **Wins**: Let's cheer for our victories, big or small.
 
 Stay constructive and kind.


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• This PR updates the Stand Down Reflections to section to incorporate "Risks". Also removed Firebreak and Emergency Planning ceremonies that we have agreed to drop.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• Update Stand Down Reflections
• Remove Emergency Planning
• Remove Firebreak Planning

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

From [WoW Review](https://miro.com/app/board/uXjVMYOTvek=/?share_link_id=531799601845)
