### PR TITLE
Updating Dependabot section

### DIFF
--- a/source/documentation/team-information/team-practises/ways-of-engineering.html.md.erb
+++ b/source/documentation/team-information/team-practises/ways-of-engineering.html.md.erb
@@ -107,7 +107,7 @@ We are experimenting with adopting PipEnv as our Python package manager, moving 
 
 ## **Security and Dependency Management**
 
-### **✅ Replace Dependabot with Trivy for CVE Dependency Management**
+### **✅ Use Dependabot**
 
 To enhance our security posture and streamline the management of vulnerabilities within our dependencies, we are experimenting with replacing Dependabot with Trivy. This shift aims to leverage Trivy's comprehensive vulnerability detection across multiple languages and package managers and ease of integration into our CI/CD pipelines. During this experimental phase, we will evaluate Trivy's effectiveness in identifying and mitigating known vulnerabilities, comparing it to Dependabot's performance and utility.
 


### PR DESCRIPTION
## 👀 Purpose

- In relation to: Updating WoE page

## ♻️ What's changed

- Removed "using Trivy" from WoE section about Dependabot and code scanning.

## 📝 Notes

-