### PR TITLE
Add place holder for dashboard user guide

### DIFF
--- a/source/documentation/finops-and-greenops-at-moj/tools/dashboard.html.md.erb
+++ b/source/documentation/finops-and-greenops-at-moj/tools/dashboard.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#coat-notifications"
 title: Cost & Usage Dashboard (Beta)
-last_reviewed_on: 2025-09-01
+last_reviewed_on: 2025-11-17
 review_in: 6 months
 ---
 
@@ -22,6 +22,10 @@ This dashboard is in **beta phase** of development.
 Access the dashboard via this link - [Cost & Usage Dashboard (Beta)](https://g-9d213fbc19.grafana-workspace.eu-west-2.amazonaws.com/d/eefmlx7flj4sgc/finops?orgId=1)
 
 Please note you will need to sign in with AWS IAM Identity Center. Access is based on your Observability Platform permissions.
+
+## How to use the Dashboard
+
+Quick start guide for using the Cost and Usage Dashboard - Coming Soon!
 
 ## How to provide feedback
 


### PR DESCRIPTION
This pull request updates the Cost & Usage Dashboard documentation with a new review date and adds a placeholder for a quick start guide. The main changes are:

Documentation updates:

* Updated the `last_reviewed_on` date in `dashboard.html.md.erb` to 2025-11-17 to reflect the latest review.
* Added a new "How to use the Dashboard" section with a placeholder note indicating that a quick start guide is coming soon.