### PR TITLE
Add an implementation complexity indicator

### DIFF
--- a/source/documentation/finops-and-greenops-at-moj/patterns/gp2-to-gp3-optimisation.html.md.erb
+++ b/source/documentation/finops-and-greenops-at-moj/patterns/gp2-to-gp3-optimisation.html.md.erb
@@ -17,6 +17,10 @@ Most workloads can migrate with no downtime, and the change can be completed dir
 
 This guide explains what GP storage is, why upgrading is beneficial, and how users can perform the upgrade safely.
 
+## Implementation Complexity
+
+**Low**
+
 ## What is General Purpose (GP) Storage?
 
 General Purpose (GP) storage is the default SSD-based storage class for Amazon Elastic Block Store (EBS). It is designed for a wide range of workloads such as application servers, development environments, boot volumes, and medium-sized databases.


### PR DESCRIPTION
This pull request adds a new section to the documentation to clarify the complexity level of migrating from GP2 to GP3 storage. This helps users quickly understand the effort required for the upgrade.

- Documentation update:
  * Added an "Implementation Complexity" section with a "Low" rating to the GP2 to GP3 optimisation guide, making it clearer how difficult the migration is for most users.