### PR TITLE
Update slack_service.py to switch to files_upload_v2()

### DIFF
--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -64,7 +64,7 @@ class SlackService:
                                  filename: str | None = None):
         try:
             with open(file_path, "rb") as file_content:
-                self.slack_client.files_upload(
+                self.slack_client.files_upload_v2(
                     channels=self.COAT_NOTIFICATIONS_CHANNEL_ID,
                     initial_comment=message,
                     file=file_content,


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• Slack have deprecated  `files_upload()`. Switching to new web API.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• Replace `files_upload()` with `files_upload_v2()`

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
