### PR TITLE
Add links to platform tagging guides

### DIFF
--- a/source/documentation/finops-and-greenops-at-moj/standards/tagging.html.md.erb
+++ b/source/documentation/finops-and-greenops-at-moj/standards/tagging.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#coat-notifications"
 title: Tagging Standard
-last_reviewed_on: 2026-03-19
+last_reviewed_on: 2026-05-14
 review_in: 6 months
 ---
 
@@ -40,3 +40,8 @@ To ensure we can consistently search for, and report on, the tags we use, you sh
 - `infrastructure-support`: The team responsible for managing the infrastructure. Should be of the form `<team-name>: <team-email>`.
 - `runbook`: The URL of [the service's runbook](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-how-your-service-is-supported.html).
 - `source-code`: The URL(s) for any source code repositories related to this infrastructure, comma separated.
+
+### Platform specific guidance for applying mandatory tags
+
+- Cloud Platform - [Updating Mandatory Tags for AWS provider in Cloud Platform namespace resources](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/mandatory-aws-tags-update.html)
+- Modernisation Platform - [How to Add Default Tags](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/how-to-add-default-tags.html#how-to-add-default-tags)


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• PR adds links to platform specific guidances on tagging. The standard tells you what to tag, but not how, so addition of guidance makes standard more actionable.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• Add links to CP and MP tag guides
