### PR TITLE
Update tagging report script to include All BU option

### DIFF
--- a/.github/workflows/job_generate_tagging_coverage_report.yml
+++ b/.github/workflows/job_generate_tagging_coverage_report.yml
@@ -12,6 +12,7 @@ on:
         required: true
         type: choice
         options:
+          - All
           - HMPPS
           - LAA
           - Central Digital
@@ -46,9 +47,34 @@ jobs:
           aws-region: eu-west-2
       - name: Run Python script
         run: |
+          BILLING_PERIOD="${{ github.event.inputs.billing_period }}"
+          SELECTED_BU="${{ github.event.inputs.business_unit }}"
+
+          BUSINESS_UNITS=(
+            "HMPPS"
+            "LAA"
+            "Central Digital"
+            "Technology Services"
+            "OPG"
+            "HMCTS"
+            "YJB"
+            "CICA"
+            "OCTO"
+          )
+
+          if [ "$SELECTED_BU" = "All" ]; then
+            for BU in "${BUSINESS_UNITS[@]}"; do
+              echo "Running report for $BU"
+              pipenv run python3 -m bin.tagging_coverage_report \
+                --billing_period "$BILLING_PERIOD" \
+                --business_unit "$BU"
+            done
+          else
+            echo "Running report for $SELECTED_BU"
             pipenv run python3 -m bin.tagging_coverage_report \
-            --billing_period "${{ github.event.inputs.billing_period }}" \
-            --business_unit "${{ github.event.inputs.business_unit }}"
+              --billing_period "$BILLING_PERIOD" \
+              --business_unit "$SELECTED_BU"
+          fi
         env:
           GH_TOKEN: ${{ secrets.ENTERPRISE_BILLING_TOKEN_FROM_TONY }}
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SLACK_TOKEN }}


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• PR updates the tagging report to include and `All` option for Business Units. If we want a full org overview we would need to run multiple reports and manually combine them. This saves time.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• Update [.github/workflows/job_generate_tagging_coverage_report.yml](https://github.com/ministryofjustice/cloud-optimisation-and-accountability/compare/main...AntonyBishop-patch-1?quick_pull=1#diff-dd79ab2caf8bad9e59b16b0d42f9bca3f4e187106cfb64402bc837827084e9aa)

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
