### PR TITLE
Update ways-of-working

### DIFF
--- a/source/documentation/team-information/team-practises/ways-of-working.html.md.erb
+++ b/source/documentation/team-information/team-practises/ways-of-working.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#coat-notifications"
 title: Ways of Working
-last_reviewed_on: 2026-02-10
+last_reviewed_on: 2026-08-13
 review_in: 6 months
 ---
 
@@ -47,56 +47,6 @@ The stories in the current sprint will depend on priorities, however we will alw
 - **sprint goal stories** - these will directly relate to roadmap priorities and form the majority of the sprint backlog.
 - **refactor story** - at least one refactor story to ensure that our code is well maintained.
 - **risk story**  - at least one story relating to items from our risk register.
-
-### **✅ Archive Repository Once a Proof of Concept is Complete**
-
-Once a Proof of Concept (POC) is complete, the associated GitHub repository should be removed from the [GitHub Repository Terraform](https://github.com/ministryofjustice/operations-engineering/tree/main/terraform/github/repositories), this will automatically archive the repository. This ensures that the repository estate is not polluted by lingering POC repositories.
-
-### 💡 Set Quarterly Goals
-
-Quarterly goals align our team's efforts with broader objectives and enhance our focus and productivity. These goals will be defined collaboratively with senior stakeholders and discussed with the team, reflecting our shared priorities and aspirations. By establishing clear, measurable targets, we aim to drive our team's progress, foster alignment, and celebrate achievements together.
-
-Quarterly Goals are:
-
-- ✅ SMART (Specific, Measurable, Achievable, Relevant, Time-bound)
-- ✅ A tool to enable effective planning, tracking, and communication of our progress - we are still an agile team and will continue to adapt and respond to change
-- ✅ A concise list of 3 goals that are achievable within the quarter
-- ✅ Aligned with the team's overall objectives and priorities
-- ✅ Regularly reviewed and updated to reflect our evolving needs and progress i.e. if a goal is completed early, we can add a new one or adjust existing goals as we learn more about our work
-- ✅ The first sprint retro of each new quarter will be a Ways Of Working reflection to discuss if any changes or updates to our working practises are required
-
-Quarterly Goals are not:
-
-- ❌ A rigid set of targets that must be met at all costs
-- ❌ A tool for de-prioritising business requirements or other priorities such as day-to-day operational work, addressing technical debt, administrative responsibilities and peoples personal learning and development time
-- ❌ A vague statement of intent or aspiration without clear, measurable outcomes
-- ❌ A static list that remains unchanged throughout the quarter - where we need to adapt our goals, we will do so and reflect on learning and insights gained
-- ❌ An extensive list of goals that dilutes our focus and makes it difficult to track progress
-
-> *Examples:*
->
-> - A Good Delivery Goal - *"Improve tagging of AWS resources by increasing meaningful coverage by 20% by the end of the quarter"*
-> - A Poor Delivery Goal - *"Improve AWS resource tagging"*
-> - A Good Discovery Goal - *"Understand the top 3 saving oppurtunities within AWS, complete with risk assessments, potential savings oppurtunities and high-level a plan for implementation by end of the quarter"*
-> - A Poor Discovery Goal - *"Understand AWS costs"*
-
-#### Measuring Success
-
-To emphasise the importance of making committed progress towards our goals, we will measure our success by how we manage to commit our time to goal and the progress we made towards it. Again, focus and dedication to the goal is key not the completion of the goal itself.
-
-We will use the following categories to measure our success of our goals:
-
-*🚀 Surpassed Expectations*
-
-Outcome: The team hit/exceeded the intended target, achieving more than expected. This reflects not only focus but exceptional performance or favourable external circumstances. This serves as an opportunity to celebrate and reflect on the factors that contributed to this outcome.
-
-*✅ Achieved Progress*
-
-Outcome: The team met the goal as far as reasonably possible, given the circumstances. This is a normal and positive outcome, emphasizing focus, dedication and progress, despite external challenges.
-
-*🙈 Underprioritised*
-
-Outcome: The team was unable to give sufficient attention to the goal. This serves as an opportunity to analyze and reflect on the barriers that led to this outcome
 
 ## **Ceremonies**
 
@@ -246,15 +196,16 @@ and create specialised views to optimise our ceremonies.
 
 Our board can be found [here](https://github.com/orgs/ministryofjustice/projects/52)
 
-### **✅ Use Slack Huddles for all Ceremonies**
+### **✅ Use MS Teams for all Ceremonies**
 
-For all team ceremonies, we use Slack Huddles for the following reasons:
+For all team ceremonies, we use MS Teams for the following reasons:
 
 - Familiar with the tool as we it for daily communication
 - Google is being decommissioned in the Ministry of Justice, so we want to move away depending on it
-- Slack Huddles contains most features we need to effectively run most ceremonies
+- Allows recording and transcription of meets to allow those who can not attend catch up
+- Maintains chat history related to specific ceremony
 
-Where Slack Huddles is not suitable for a particular meeting, we can opt to use an alternative tool.
+Where MS Teams is not suitable for a particular meeting, we can opt to use an alternative tool.
 
 ---
 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• Updates to Ways of Working to remove processes no longer followed and updates to changes in WoW.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

This pull request updates the team's Ways of Working documentation to reflect recent changes in team practices and tools. The most significant updates include the removal of sections on archiving repositories and quarterly goals, and a switch from Slack Huddles to MS Teams for all ceremonies.

**Removed practices and goals:**

* Removed the section on archiving repositories after completing a Proof of Concept (POC) to streamline documentation -  The process was the Ops Eng Process so no longer applies.
* Removed the detailed section on setting and measuring quarterly goals - This has been replaced by standard OKR process

**Tooling update for ceremonies:**

* Updated the documentation to specify the use of MS Teams instead of Slack Huddles for all team ceremonies, highlighting benefits such as meeting recordings, transcriptions, and chat history.

**Administrative update:**

* Updated the `last_reviewed_on` date to reflect the latest review of the document.